### PR TITLE
Add Diffie-Hellman Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ gen :: Point f c e q r
 
 ### Point Arithmetic
 
-See [**Example.hs**](Example.hs).
+See [**Example.hs**](examples/Example.hs).
+
+### Elliptic Curve Diffie-Hellman (ECDH)
+
+See [**DiffieHellman.hs**](examples/DiffieHellman.hs).
 
 ### Representing a new curve using the curve class
 

--- a/elliptic-curve.cabal
+++ b/elliptic-curve.cabal
@@ -4,7 +4,7 @@ cabal-version:      1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1685b0e4e19d59c9fb65b33582c33c80521962a9dad4be789a5cd9c1401824cb
+-- hash: cd153de32e11244f897a72cbcfc0169c7ca4b88664a71ac709422e44e887d92d
 
 name:               elliptic-curve
 version:            0.3.1
@@ -228,8 +228,13 @@ test-suite elliptic-curve-tests
 
 test-suite example-test
   type:               exitcode-stdio-1.0
-  main-is:            Example.hs
-  other-modules:      Paths_elliptic_curve
+  main-is:            Main.hs
+  other-modules:
+    DiffieHellman
+    Example
+    Paths_elliptic_curve
+
+  hs-source-dirs:     examples
   default-extensions:
     NoImplicitPrelude
     DataKinds

--- a/examples/DiffieHellman.hs
+++ b/examples/DiffieHellman.hs
@@ -1,12 +1,12 @@
 module DiffieHellman where
 
 import Data.Curve.Montgomery.Curve25519 as Curve25519
-import qualified Data.Field.Galois as Fq
+import qualified Data.Field.Galois as Fr
 import Protolude
 
 -- Generate random private point on Curve25519
 generate :: IO Curve25519.Fr
-generate = Fq.rnd
+generate = Fr.rnd
 
 main :: IO ()
 main = do

--- a/examples/DiffieHellman.hs
+++ b/examples/DiffieHellman.hs
@@ -1,0 +1,32 @@
+module DiffieHellman where
+
+import Data.Curve.Montgomery.Curve25519 as Curve25519
+import qualified Data.Field.Galois as Fq
+import Protolude
+
+-- Generate random private point on Curve25519
+generate :: IO Curve25519.Fr
+generate = Fq.rnd
+
+main :: IO ()
+main = do
+  alice_private <- generate
+  bob_private <- generate
+  let bob_public :: Curve25519.PA
+      bob_public = gen `mul` bob_private
+      alice_public :: Curve25519.PA
+      alice_public = gen `mul` alice_private
+  let shared_secret1 = bob_public `mul` alice_private
+      shared_secret2 = alice_public `mul` bob_private
+  putText "Alice Private Key:"
+  print alice_private
+  putText "Alice Public Key:"
+  print alice_public
+  putText "Bob Private Key:"
+  print bob_private
+  putText "Bob Public Key:"
+  print bob_public
+  putText "Diffie Hellman Shared Secret"
+  print shared_secret1
+  print (shared_secret1 == shared_secret2)
+  pure ()

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -1,3 +1,5 @@
+module Example where
+
 import Data.Curve.Edwards.Ed25519 as Ed25519
 import Protolude
 
@@ -47,6 +49,3 @@ p9 = Ed25519.fromA p8
 -- get y coordinate (point from Fq) from coordinate
 p10 :: Maybe Ed25519.Fq
 p10 = Ed25519.yX p1 (2 :: Fq)
-
-main :: IO ()
-main = print p1

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,0 +1,8 @@
+module Main where
+
+import qualified DiffieHellman
+import qualified Example
+import Protolude
+
+main :: IO ()
+main = pure ()

--- a/package.yaml
+++ b/package.yaml
@@ -187,7 +187,8 @@ tests:
       - elliptic-curve
       - base              >= 4.10 && < 5
       - protolude         >= 0.2  && < 0.3
-    main: Example.hs
+    source-dirs: examples
+    main: Main.hs
 
 benchmarks:
   elliptic-curve-benchmarks:


### PR DESCRIPTION
Add Diffie-Hellman key exchange example for Curve25519. Probably the most common use case for this library. 